### PR TITLE
Added HULOG to Organisational list

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 ## Organisational
 *Apps to organize your life like calendars or task lists*
 
+* [HULOG](https://hulog.reichel.dev) - A Mac and iOS app for quickly taking timestamped notes during meetings or oncall incidents.
 * [Taskade](https://taskade.com/downloads) - Beautiful task lists, notes and team workspaces on your Mac.
 
 ## Photo and Video


### PR DESCRIPTION
Adding HULOG, a tool custom built to handle timestamped note-taking. 

Though I did build this, my goal was for it to support folks on a Mac that need to take accurate meeting minutes or notes during critical incidents.  