### PR TITLE
Add HeyRobyn to E-Mail section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 *Programs which are used to access and manage a user's email*
 
 * [Airmail](http://airmailapp.com) - Lightning Fast Mail Client for Mac and iPhone.
+* [HeyRobyn](https://heyrobyn.ai) - Native Mac unified inbox for email, Slack, and GitHub in one window.
 * [N1](https://www.nylas.com/n1) - The extensible, open source mail client.
 * [Postbox](https://www.postbox-inc.com) - Another powerful Mail Client for Mac.
 


### PR DESCRIPTION
**Application**: HeyRobyn
**Link**: https://heyrobyn.ai
**Description**: Native Mac unified inbox for email, Slack, and GitHub in one window.

HeyRobyn is a productivity tool that consolidates email, Slack messages, and GitHub notifications into a single native macOS application. Built with SwiftUI for performance, it provides a privacy-first approach with all data stored on-device.

**Why this is useful:**
- Native Mac app (SwiftUI, not Electron)
- Unified inbox for multiple communication channels
- Privacy-focused with on-device data storage
- Designed specifically for Mac users who juggle multiple communication tools

Thank you for maintaining this awesome list!