### PR TITLE
Add Lockpaw to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [1Password](https://agilebits.com/onepassword/mac) - A comprehensive password manager.
 * [Boxcryptor](https://www.boxcryptor.com) - A tool to encript your sensitive files in your cloud storage.
 * [Dashlane](https://www.dashlane.com/) - An another password manager & secure digital wallet.
+* [Lockpaw](https://getlockpaw.com) - A menu bar screen guard that lets you lock and unlock your Mac with a hotkey, with Touch ID fallback.
 * [Pareto Security](https://paretosecurity.app/) - A MenuBar app to automatically audit your Mac for basic security hygiene.
 
 


### PR DESCRIPTION
[Lockpaw](https://getlockpaw.com) is a free and open-source macOS menu bar screen guard. Lock and unlock your screen with a hotkey, with Touch ID fallback.

- Website: https://getlockpaw.com
- Repository: https://github.com/sorkila/lockpaw
- License: MIT