### PR TITLE
Add SnapHotkey — keyboard shortcuts directly to specific Mac apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [MacID](http://macid.co) - Unlock your Mac with just your fingerprint.™
 * [Onyx](http://www.titanium.free.fr/onyx.html) - The multifunction Utility.
 * [Paste](http://pasteapp.me/) - Keep track of your clipboard.
+* [SnapHotkey](https://snaphotkey.com) - Map keyboard shortcuts directly to specific Mac apps for instant one-keypress access. Features left/right modifier distinction, toggle show/hide, and same-app multi-window cycling.
 * [Spectacle](http://spectacleapp.com) - Window control with simple and customizable keyboard shortcuts.
 * [Kap](https://getkap.co/) - Kap. Capture your screen
 * [Muzzle](https://muzzleapp.com) - A simple mac app to silence embarrassing notifications while screensharing.


### PR DESCRIPTION
## Add SnapHotkey to Utilities

[SnapHotkey](https://snaphotkey.com) is a macOS utility that maps keyboard shortcuts directly to specific apps for instant one-keypress access.

**Why it belongs here:** It fits alongside BetterTouchTool and Spectacle in the Utilities section — a small background app that enhances how you interact with macOS through keyboard shortcuts.

**What makes it distinct:**
- Maps any key combination directly to a specific app (e.g., `Left Cmd+1` = VS Code, `Left Cmd+2` = Terminal)
- Distinguishes Left Command from Right Command as separate modifiers (unique capability)
- Toggle show/hide: same shortcut hides the app when it's already focused
- Same-app multi-window cycling: repeated presses cycle through all windows of that app

**Category:** Utilities (alongside Alfred, BetterTouchTool, Spectacle)
**Platform:** macOS
**Price:** $9.99 one-time / free with 3 rules
**License:** Commercial