### PR TITLE
Add Waindow to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Kap](https://getkap.co/) - Kap. Capture your screen
 * [Muzzle](https://muzzleapp.com) - A simple mac app to silence embarrassing notifications while screensharing.
 * [Freeter](https://freeter.io) - Gather everything you need for work in one place, organized by projects and workflows, and have a quick access to them. Free and Open-Source.
+* [Waindow](https://www.waindow.app/) - Free native Mac utility for arranging windows, window memos, long-page capture, and Keep Awake.
 
 ## Security
 *Encryption, Password Manager and other tools for your safety*


### PR DESCRIPTION
Adds Waindow to the Utilities section using the project format from CONTRIBUTING.md.\n\nWaindow is a free, account-free native macOS utility for window arrangements, window-linked Markdown memos, long-page capture, Linked Resize, Blackout Mode, and Keep Awake. The current public preview is a compiled Universal Mac build; its source is not publicly distributed.\n\nWebsite: https://www.waindow.app/