### PR TITLE
Add Nexus Shell to FTP Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Please see [CONTRIBUTING](https://github.com/xyNNN/awesome-mac/blob/master/CONTR
 * [Cyberduck](https://cyberduck.io) - Libre FTP, SFTP, WebDAV, S3 & OpenStack Swift client.
 * [FileZilla](https://filezilla-project.org) - A fast and reliable cross-platform FTP, FTPS and SFTP client.
 * [Flow](http://fivedetails.com/flow/) - The Mac's Best FTP + SFTP Client.
+* [Nexus Shell](https://nexusshell.app/en/) - A native macOS SSH and SFTP workspace with terminal tabs, file transfers, key management, and server monitoring.
 * [Transmit](http://www.panic.com/transmit/) - The ultimate Mac OS X FTP + SFTP + S3 app.
 
 ## Finance


### PR DESCRIPTION
## What changed

- Add Nexus Shell to the FTP Clients section.
- Keep the entry in alphabetical order and use the repository's required one-line format.

## Why

Nexus Shell is a native macOS SSH and SFTP workspace. The section already covers Mac clients that connect to servers over SFTP, so this is the closest existing category.

## Verification

- Searched the list for an existing Nexus Shell entry.
- Confirmed `https://nexusshell.app/en/` returns HTTP 200.
- Ran `git diff --check` successfully.

Disclosure: I am submitting this as the Nexus Shell developer.
